### PR TITLE
Bug/sonarscan in docker

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-b0f895839f3f0a5798bb9a55e8755b62452530ab
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v0.1.5
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v0.1.4
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-b0f895839f3f0a5798bb9a55e8755b62452530ab
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/scripts/docker_sonarscan.sh
+++ b/scripts/docker_sonarscan.sh
@@ -9,9 +9,11 @@ cleanup() {
 
 trap "cleanup" EXIT
 eval "docker build --target $INPUT_SONAR_SCAN_IN_DOCKER_TARGET -t sonarscan . $(for i in $(env); do out+="--build-arg $i "; done; echo "$out")"
-args="-e SONAR_TOKEN sonarscan -d testresults -o $SONAR_ORG -k $SONAR_PROJECT_KEY -r $GITHUB_SHA"
+args=("-d testresults" "-o $SONAR_ORG" "-k $SONAR_PROJECT_KEY" "-r $GITHUB_SHA")
 if [ -z "$PULL_REQUEST_KEY" ]; then
-  docker run --rm "$args" -b "$BRANCH_NAME"
+    args+=("-b $BRANCH_NAME")
 else
-  docker run --rm "$args" -p "$PULL_REQUEST_KEY"
+    args+=("-p $PULL_REQUEST_KEY")
 fi
+
+docker run --rm -e SONAR_TOKEN sonarscan "${args[@]}"

--- a/scripts/docker_sonarscan.sh
+++ b/scripts/docker_sonarscan.sh
@@ -10,7 +10,7 @@ cleanup() {
 trap "cleanup" EXIT
 eval "docker build --target $INPUT_SONAR_SCAN_IN_DOCKER_TARGET -t sonarscan . $(for i in $(env); do out+="--build-arg $i "; done; echo "$out")"
 args=("-d testresults" "-o $SONAR_ORG" "-k $SONAR_PROJECT_KEY" "-r $GITHUB_SHA")
-if [ -z "$PULL_REQUEST_KEY" ]; then
+if [ "$PULL_REQUEST_KEY" = null ]; then
     args+=("-b $BRANCH_NAME")
 else
     args+=("-p $PULL_REQUEST_KEY")


### PR DESCRIPTION
# Description

Fixes some issues with running sonarscan using the user provided docker image and target stage. The parameterized arguments weren't rendering into the command correctly, and the PULL_REQUEST_KEY check wasn't updated to null after the jq changes were made in the upstream script that sets this value. 

The jq thing could be fixed for both checks by piping the result in the match to `| values`. That would render the null as an empty string instead, which would work with the typical `-z` check.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [x] Sanity Testing

Successful run example here https://github.com/variant-inc/assignments-api/runs/2096666355