### PR TITLE
Feature/upgrade dotnet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine
 
 ARG BUILD_DATE
 ARG BUILD_REVISION

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.0.3
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-b987f67d2958861f01518163ad4491365cc81487
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-ARG VERSION=3.1-alpine
+ARG VERSION=5.0-alpine
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:$VERSION
+FROM mcr.microsoft.com/dotnet/aspnet:$VERSION
 RUN apk add --no-cache tzdata
 WORKDIR /app
 COPY publish .


### PR DESCRIPTION
# Description

This change upgrades containers used by the action from .NET Core 3.1 -> .NET 5. 

I decided not to make the image URL a variable in the spirit of this action being the centralized place for building/publishing dotnet apps/images.

Also, because .NET 5 is backwards-compatible, we don't need the image URL to be configurable since it will support the `TargetFramework` specified.


## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X] Sanity Testing an app on .NET 5
* https://github.com/variant-inc/schedule-adherence/runs/2604402464?check_suite_focus=true
* https://github.com/variant-inc/schedule-adherence/commit/edc6790ebba6ac57b2b2695a434be95106319921
* The workflow is in failed state because of a repeated Octopus release name. The successful action run can be seen in the step "Lazy CI"
- [X] Sanity Testing an app on .NET Core 3.1
* https://github.com/variant-inc/ticketing/runs/2604476774?check_suite_focus=true
* https://github.com/variant-inc/ticketing/compare/f/EH-000/upgrade-dotnet-action?expand=1
* Successful action run can be seen in step "CI"


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
