### PR TITLE
Feature/cloud 450 ecr create script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.0.6
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.0.5
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-3028229faff9ea17b913aeeb0679354d6220dbc3 #v1.0.3
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.0.3
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.0.3
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-3028229faff9ea17b913aeeb0679354d6220dbc3 #v1.0.3
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.0.3
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.0.6
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.0.5
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.1.0
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ cd "$INPUT_SRC_FILE_DIR_PATH"
 echo "Current directory: $(pwd)"
 
 echo "Cloning into actions-collection..."
-git clone -b feature/CLOUD-450-ecr-create-script https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 export AWS_WEB_IDENTITY_TOKEN_FILE="/token"
 echo "$AWS_WEB_IDENTITY_TOKEN" >> "$AWS_WEB_IDENTITY_TOKEN_FILE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ cd "$INPUT_SRC_FILE_DIR_PATH"
 echo "Current directory: $(pwd)"
 
 echo "Cloning into actions-collection..."
-git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b feature/CLOUD-450-ecr-create-script https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 export AWS_WEB_IDENTITY_TOKEN_FILE="/token"
 echo "$AWS_WEB_IDENTITY_TOKEN" >> "$AWS_WEB_IDENTITY_TOKEN_FILE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ sh -c "/scripts/coverage_scan.sh"
 echo "End: Sonar Scan"
 
 echo "Start: Checking ECR Repo"
-./actions-collection/collection.sh ecr_create "$INPUT_ECR_REPOSITORY"
+./actions-collection/scripts/ecr_create.sh "$INPUT_ECR_REPOSITORY"
 echo "End: Checking ECR Repo"
 
 echo "Container Push: $INPUT_CONTAINER_PUSH_ENABLED"


### PR DESCRIPTION
# Description

Moved ecr_create() function to ecr_creat.sh in scripts. This is called in actions-dotnet and actions-nodejs.

Feature [CLOUD-450](https://usxtech.atlassian.net/browse/CLOUD-450)

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- [x] Sanity Testing
- https://github.com/variant-inc/demo-app/runs/2877675538?check_suite_focus=true
  - Line 865-894 displays ecr_create.sh creating anew repo. However the pipeline fails due to trivy_scan.sh

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added documentation to test
