### PR TITLE
Feature/cloud 1412 coverlet msbuild

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -18,8 +18,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_KUBERNETES_KUBEVAL: false
+          VALIDATE_GITHUB_ACTIONS: false

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.1.4
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:test-latest
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:test-latest
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.2.0
   env:
     GITHUB_TOKEN: ${{ inputs.nuget_pull_token }}

--- a/scripts/cover.ps1
+++ b/scripts/cover.ps1
@@ -28,7 +28,7 @@ $tests = $(dotnet sln $solutionFileDir list) | Select-Object -Skip 2 | Where-Obj
 $tests | ForEach-Object {
   $file = [System.IO.DirectoryInfo]"$_"
   $parent = $($file.parent.fullname)
-  ce dotnet add $parent package coverlet.collector
+  ce dotnet add $parent package coverlet.msbuild
 }
 
 $OUTPUTDIR = "coverage"

--- a/scripts/cover.ps1
+++ b/scripts/cover.ps1
@@ -28,9 +28,8 @@ $tests = $(dotnet sln $solutionFileDir list) | Select-Object -Skip 2 | Where-Obj
 $tests | ForEach-Object {
   $file = [System.IO.DirectoryInfo]"$_"
   $parent = $($file.parent.fullname)
-  ce dotnet add $parent package coverlet.msbuild coverlet.collector
-  # ce dotnet add $parent package coverlet.collector
-
+  ce dotnet add $parent package coverlet.msbuild
+  ce dotnet add $parent package coverlet.collector
 }
 
 $OUTPUTDIR = "coverage"

--- a/scripts/cover.ps1
+++ b/scripts/cover.ps1
@@ -29,6 +29,8 @@ $tests | ForEach-Object {
   $file = [System.IO.DirectoryInfo]"$_"
   $parent = $($file.parent.fullname)
   ce dotnet add $parent package coverlet.msbuild
+  ce dotnet add $parent package coverlet.collector
+
 }
 
 $OUTPUTDIR = "coverage"

--- a/scripts/cover.ps1
+++ b/scripts/cover.ps1
@@ -28,8 +28,8 @@ $tests = $(dotnet sln $solutionFileDir list) | Select-Object -Skip 2 | Where-Obj
 $tests | ForEach-Object {
   $file = [System.IO.DirectoryInfo]"$_"
   $parent = $($file.parent.fullname)
-  ce dotnet add $parent package coverlet.msbuild
-  ce dotnet add $parent package coverlet.collector
+  ce dotnet add $parent package coverlet.msbuild coverlet.collector
+  # ce dotnet add $parent package coverlet.collector
 
 }
 


### PR DESCRIPTION
# Description

Adding coverlet msbuild

Fixes [#23](https://usxtech.atlassian.net/browse/LAZY-1412)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```yaml
Pre reqs:
  - Create branch on any dotnet project by pointing to dotnet action ms build branch
Test Case 1 [Run on repos with new dotnet action changes]:
- Steps
  - Can re-run the branches in the sample runs below and see it is running new nuget related changes.
  - Or  create a new branch on  new reposand see new nuget related changes are running. 
  - Pick projects where nuget_push_enabled=true on those projects as this nuget related change.
- Sample runs
  - https://github.com/variant-inc/trailers-api/actions/runs/1713173809
  - https://github.com/variant-inc/schedule-adherence/runs/4854105773?check_suite_focus=true
```

```text
Note: I will update the action.yaml to minor version as i receive the approvals on this PR.
```

- [ ] Unit Tests
- [x] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
