### PR TITLE
Feature/cloud 1738 skip sonar run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,4 @@ inputs:
     default: "true"
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.4.5
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-ad4ed44189033bb2256aa87aa103e828a28020cd

--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,4 @@ inputs:
     default: "true"
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-ad4ed44189033bb2256aa87aa103e828a28020cd
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.5.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,9 +43,8 @@ echo "End: Enable sonar"
 
 echo "Start: Check sonar run"
 skip_sonar_run=$(pwsh ./actions-collection/scripts/skip_sonar_run.ps1)
-echo "Skip sonar run: $skip_sonar_run"
+echo "Skip sonar run : $skip_sonar_run"
 echo "End: Check sonar run"
-
 
 if [ "$skip_sonar_run" != 'True' ]; then
   echo "Start: Sonar Scan"
@@ -55,23 +54,22 @@ else
   echo "End: Skipping sonar run"
 fi
 
-# echo "Container Push: $INPUT_CONTAINER_PUSH_ENABLED"
-# if [ "$INPUT_CONTAINER_PUSH_ENABLED" = 'true' ]; then
-#   echo "Start: Checking ECR Repo"
-#   ./actions-collection/scripts/ecr_create.sh "$INPUT_ECR_REPOSITORY"
-#   echo "End: Checking ECR Repo"
-#   echo "Start: Publish Image to ECR"
-#   ./actions-collection/scripts/publish.sh
-#   echo "End: Publish Image to ECR"
-# fi
+echo "Container Push: $INPUT_CONTAINER_PUSH_ENABLED"
+if [ "$INPUT_CONTAINER_PUSH_ENABLED" = 'true' ]; then
+  echo "Start: Checking ECR Repo"
+  ./actions-collection/scripts/ecr_create.sh "$INPUT_ECR_REPOSITORY"
+  echo "End: Checking ECR Repo"
+  echo "Start: Publish Image to ECR"
+  ./actions-collection/scripts/publish.sh
+  echo "End: Publish Image to ECR"
+fi
 
-
-# echo "Nuget Publish: $INPUT_NUGET_PUSH_ENABLED"
-# if [ "$INPUT_NUGET_PUSH_ENABLED" = 'true' ]; then
-#   echo "Start: Publish Nuget Package"
-#   /scripts/nuget_push.sh
-#   echo "End: Publish Nuget Package"
-# fi
+echo "Nuget Publish: $INPUT_NUGET_PUSH_ENABLED"
+if [ "$INPUT_NUGET_PUSH_ENABLED" = 'true' ]; then
+  echo "Start: Publish Nuget Package"
+  /scripts/nuget_push.sh
+  echo "End: Publish Nuget Package"
+fi
 
 echo "Start: Clean up"
 git clean -fdx

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ echo "Current directory: $(pwd)"
 git config --global --add safe.directory /github/workspace
 
 echo "Cloning into actions-collection..."
-git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b feature/CLOUD-1738-skip-sonar-analysis https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 echo "---Start: Pretest script"
 chmod +x ./actions-collection/scripts/pre_test.sh
@@ -41,26 +41,37 @@ echo "Start: Enable sonar"
 pwsh ./actions-collection/scripts/enable_sonar.ps1
 echo "End: Enable sonar"
 
-echo "Start: Sonar Scan"
-sh -c "/scripts/coverage_scan.sh"
-echo "End: Sonar Scan"
+echo "Start: Check sonar run"
+skip_sonar_run=$(pwsh ./actions-collection/scripts/skip_sonar_run.ps1)
+echo "Skip sonar run: $skip_sonar_run"
+echo "End: Check sonar run"
 
-echo "Container Push: $INPUT_CONTAINER_PUSH_ENABLED"
-if [ "$INPUT_CONTAINER_PUSH_ENABLED" = 'true' ]; then
-  echo "Start: Checking ECR Repo"
-  ./actions-collection/scripts/ecr_create.sh "$INPUT_ECR_REPOSITORY"
-  echo "End: Checking ECR Repo"
-  echo "Start: Publish Image to ECR"
-  ./actions-collection/scripts/publish.sh
-  echo "End: Publish Image to ECR"
+
+if [ "$skip_sonar_run" != 'True' ]; then
+  echo "Start: Sonar Scan"
+  sh -c "/scripts/coverage_scan.sh"
+  echo "End: Sonar Scan"
+else
+  echo "End: Skipping sonar run"
 fi
 
-echo "Nuget Publish: $INPUT_NUGET_PUSH_ENABLED"
-if [ "$INPUT_NUGET_PUSH_ENABLED" = 'true' ]; then
-  echo "Start: Publish Nuget Package"
-  /scripts/nuget_push.sh
-  echo "End: Publish Nuget Package"
-fi
+# echo "Container Push: $INPUT_CONTAINER_PUSH_ENABLED"
+# if [ "$INPUT_CONTAINER_PUSH_ENABLED" = 'true' ]; then
+#   echo "Start: Checking ECR Repo"
+#   ./actions-collection/scripts/ecr_create.sh "$INPUT_ECR_REPOSITORY"
+#   echo "End: Checking ECR Repo"
+#   echo "Start: Publish Image to ECR"
+#   ./actions-collection/scripts/publish.sh
+#   echo "End: Publish Image to ECR"
+# fi
+
+
+# echo "Nuget Publish: $INPUT_NUGET_PUSH_ENABLED"
+# if [ "$INPUT_NUGET_PUSH_ENABLED" = 'true' ]; then
+#   echo "Start: Publish Nuget Package"
+#   /scripts/nuget_push.sh
+#   echo "End: Publish Nuget Package"
+# fi
 
 echo "Start: Clean up"
 git clean -fdx

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ echo "Current directory: $(pwd)"
 git config --global --add safe.directory /github/workspace
 
 echo "Cloning into actions-collection..."
-git clone -b feature/CLOUD-1738-skip-sonar-analysis https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 echo "---Start: Pretest script"
 chmod +x ./actions-collection/scripts/pre_test.sh


### PR DESCRIPTION
# Description

Skip sonar run in case of re-run.

Fixes [#31](https://usxtech.atlassian.net/browse/CLOUD-1738)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

[Demo App Main](https://github.com/variant-inc/demo-app/tree/test/branch-naveen-sonar-run)

```yaml
Test Case 1: Sonar Should run
  1. Navigate to demo app branch create a commit.
  2. Should trigger sonar run. Also verify in sonar if results are pushed.

Result
  - Expected: See sonar is run on the commit.
  - Actual: 

Test Case 2: Skip sonar run
  1. Navigate to actions and pick the run previously created.
  2. Re-run the build, it should trigger sonar run as sonar has already been run on this commit.

Result
  - Expected: See sonar is skipped, lazy action step logs should say sonar is skipped.
```

- [ ] Unit Tests
- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
