### PR TITLE
F/cloud 1741

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,4 @@ inputs:
     default: "true"
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:test-latest
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-b48d8b3a12ea10f2a5cbf58d3142def2181f0814

--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,4 @@ inputs:
     default: "true"
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.6.0
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:test-latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ echo "Current directory: $(pwd)"
 git config --global --add safe.directory /github/workspace
 
 echo "Cloning into actions-collection..."
-git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b f/CLOUD-1741 https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 echo "---Start: Pretest script"
 chmod +x ./actions-collection/scripts/pre_test.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 function finish {
-  set -x
   chown -R 1000:1000 "$GITHUB_WORKSPACE"/*
   git clean -fdx
   set +x

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 function finish {
+  set -x
   chown -R 1000:1000 "$GITHUB_WORKSPACE"/*
   git clean -fdx
   set +x

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -17,7 +17,7 @@ trap "cleanup" EXIT
 
 echo "Connecting to AWS account."
 
-docker login -u AWS -p "$(aws ecr get-login-password)" "$ECR_REGISTRY"
+docker login -u AWS -p "$(aws ecr get-login-password)" "$ECR_REGISTRY" >/dev/null
 
 DOCKERFILE_PATH="$INPUT_DOCKERFILE_DIR_PATH"
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -17,7 +17,7 @@ trap "cleanup" EXIT
 
 echo "Connecting to AWS account."
 
-docker login -u AWS -p "$(aws ecr get-login-password)" "$ECR_REGISTRY" >/dev/null
+docker login -u AWS -p "$(aws ecr get-login-password)" "$ECR_REGISTRY"
 
 DOCKERFILE_PATH="$INPUT_DOCKERFILE_DIR_PATH"
 


### PR DESCRIPTION
# Description

Removes echoing of docker parameters to logs and removes aws ecr creds from being echoed to logs.

Fixes [CLOUD-1741](https://drivevariant.atlassian.net/browse/CLOUD-1741)

I will dotnet-action version to `v1.6.1` after the PR has been approved.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

[Testing Branch and repo](https://github.com/variant-inc/dx-demo-dotnet-api/tree/f/CLOUD-1741)

Test Case 1 [control (current behavior)]:
- Steps
  - set  the `uses` for `actions-dotnet` to be `v1`:  `uses: variant-inc/actions-dotnet@v1` in https://github.com/variant-inc/dx-demo-dotnet-api/blob/f/CLOUD-1741/.github/workflows/octo-push.yaml
  - commit and push
  - review the `CI` > `Run variant-inc/actions-dotnet@v1` step
- Results
  - There will be docker parameters and aws ecr creds logged, including:
    - [docker login](https://github.com/variant-inc/dx-demo-dotnet-api/runs/6926223494?check_suite_focus=true#step:5:966)
    - [aws ecr creds](https://github.com/variant-inc/dx-demo-dotnet-api/runs/6926223494?check_suite_focus=true#step:5:976)
    - [docker build](https://github.com/variant-inc/dx-demo-dotnet-api/runs/6926223494?check_suite_focus=true#step:5:1624)
    - [docker image rm](https://github.com/variant-inc/dx-demo-dotnet-api/runs/6926223494?check_suite_focus=true#step:5:1993)
 
Test Case 2 [apply the fix]:
- Steps
  - set  the `uses` for `actions-dotnet` to be `f/CLOUD-1741`:  `uses: variant-inc/actions-dotnet@f/CLOUD-1741` in https://github.com/variant-inc/dx-demo-dotnet-api/blob/f/CLOUD-1741/.github/workflows/octo-push.yaml
- Results
  - The docker parameters and aws ecr creds are no longer logged
  - [example](https://github.com/variant-inc/dx-demo-dotnet-api/runs/6926993876?check_suite_focus=true)
  - testing hint: search for `docker` in the log

- [x] Unit Tests
- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
