### PR TITLE
Feature/cloud 1740 skip image push

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,4 @@ inputs:
     default: "true"
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:test-latest
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.6.1

--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,4 @@ inputs:
     default: "true"
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.6.0
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:test-latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ echo "Current directory: $(pwd)"
 git config --global --add safe.directory /github/workspace
 
 echo "Cloning into actions-collection..."
-git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b f/CLOUD-1740-skip-image-push https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 echo "---Start: Pretest script"
 chmod +x ./actions-collection/scripts/pre_test.sh
@@ -60,17 +60,17 @@ if [ "$INPUT_CONTAINER_PUSH_ENABLED" = 'true' ]; then
   ./actions-collection/scripts/ecr_create.sh "$INPUT_ECR_REPOSITORY"
   echo "End: Checking ECR Repo"
   echo "Start: Publish Image to ECR"
-  ./actions-collection/scripts/publish.sh
+  pwsh ./actions-collection/scripts/publish.ps1
   echo "End: Publish Image to ECR"
 fi
 
-echo "Nuget Publish: $INPUT_NUGET_PUSH_ENABLED"
-if [ "$INPUT_NUGET_PUSH_ENABLED" = 'true' ]; then
-  echo "Start: Publish Nuget Package"
-  /scripts/nuget_push.sh
-  echo "End: Publish Nuget Package"
-fi
-
+# echo "Nuget Publish: $INPUT_NUGET_PUSH_ENABLED"
+# if [ "$INPUT_NUGET_PUSH_ENABLED" = 'true' ]; then
+#   echo "Start: Publish Nuget Package"
+#   /scripts/nuget_push.sh
+#   echo "End: Publish Nuget Package"
+# fi
+#
 echo "Start: Clean up"
 git clean -fdx
 echo "End: Clean up"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ echo "Current directory: $(pwd)"
 git config --global --add safe.directory /github/workspace
 
 echo "Cloning into actions-collection..."
-git clone -b f/CLOUD-1740-skip-image-push https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 echo "---Start: Pretest script"
 chmod +x ./actions-collection/scripts/pre_test.sh
@@ -64,13 +64,13 @@ if [ "$INPUT_CONTAINER_PUSH_ENABLED" = 'true' ]; then
   echo "End: Publish Image to ECR"
 fi
 
-# echo "Nuget Publish: $INPUT_NUGET_PUSH_ENABLED"
-# if [ "$INPUT_NUGET_PUSH_ENABLED" = 'true' ]; then
-#   echo "Start: Publish Nuget Package"
-#   /scripts/nuget_push.sh
-#   echo "End: Publish Nuget Package"
-# fi
-#
+echo "Nuget Publish: $INPUT_NUGET_PUSH_ENABLED"
+if [ "$INPUT_NUGET_PUSH_ENABLED" = 'true' ]; then
+  echo "Start: Publish Nuget Package"
+  /scripts/nuget_push.sh
+  echo "End: Publish Nuget Package"
+fi
+
 echo "Start: Clean up"
 git clean -fdx
 echo "End: Clean up"


### PR DESCRIPTION
# Description

Skip ecr image if it is already generated.

Fixes [#19](https://usxtech.atlassian.net/browse/CLOUD-1740)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

[Demo App](https://github.com/variant-inc/demo-app/tree/test/skip-image)

```yaml
Test Case 1: ECR image should be pushed and existing flow should remain same
  1. Navigate to demo app branch create a commit.
  2. Should trigger run and existing flow should remain same and push image to ECR
  3. Look for log "New image, proceeding to docker push"

Result
  - Expected: See image is pushed with that commit.
  - Actual: 

Test Case 2: Skip image push when re-run
  1. Navigate to actions and pick the run previously created.
  2. Re-run the build, it should trigger the run and should not push image to ECR.
  4. Look for log "Image already pushed. Skipping docker push"

Result
  - Expected: ECR image push should be skipped.
```

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
