### PR TITLE
F/dotnet test project filter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,4 @@ inputs:
     default: "true"
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-2fa6d4634f9fef0d4350195ac74ec4f0685f93ba
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-cc57120b3fd81d403f11bc2aad19ee5849ee6b8e

--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,4 @@ inputs:
     default: "true"
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-cc57120b3fd81d403f11bc2aad19ee5849ee6b8e
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.6.2

--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,4 @@ inputs:
     default: "true"
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.6.2
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:test-latest

--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,4 @@ inputs:
     default: "true"
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:v1.6.0
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/dotnet-action:sha-2fa6d4634f9fef0d4350195ac74ec4f0685f93ba

--- a/scripts/cover.ps1
+++ b/scripts/cover.ps1
@@ -24,7 +24,7 @@ function CommandAliasFunction
 
 Set-Alias -Name ce -Value CommandAliasFunction -Scope script
 
-$tests = $(dotnet sln $solutionFileDir list) | Select-Object -Skip 2 | Where-Object { $_ -match "^tests//" }
+$tests = $(dotnet sln $solutionFileDir list) | Select-Object -Skip 2 | Where-Object { $_ -match "test" }
 $tests | ForEach-Object {
   $file = [System.IO.DirectoryInfo]"$_"
   $parent = $($file.parent.fullname)

--- a/scripts/cover.ps1
+++ b/scripts/cover.ps1
@@ -24,7 +24,7 @@ function CommandAliasFunction
 
 Set-Alias -Name ce -Value CommandAliasFunction -Scope script
 
-$tests = $(dotnet sln $solutionFileDir list) | Select-Object -Skip 2 | Where-Object { $_ -match "test" }
+$tests = $(dotnet sln $solutionFileDir list) | Select-Object -Skip 2 | Where-Object { $_ -match "^tests//" }
 $tests | ForEach-Object {
   $file = [System.IO.DirectoryInfo]"$_"
   $parent = $($file.parent.fullname)

--- a/scripts/sonarscan.sh
+++ b/scripts/sonarscan.sh
@@ -9,8 +9,8 @@ SONAR_ORGANIZATION="$SONAR_ORG"
 
 sonar_logout() {
   set +ue
-  dotnet-sonarscanner end /d:sonar.login="$SONAR_TOKEN"
   exit_code=$?
+  dotnet-sonarscanner end /d:sonar.login="$SONAR_TOKEN"
   if [ "$exit_code" -eq 0 ]; then
     echo -e "\e[1;32m ________________________________________________________________\e[0m"
     echo -e "\e[1;32m Quality Gate Passed.\e[0m"

--- a/scripts/sonarscan.sh
+++ b/scripts/sonarscan.sh
@@ -8,8 +8,8 @@ mkdir -p "$OUTPUTDIR"
 SONAR_ORGANIZATION="$SONAR_ORG"
 
 sonar_logout() {
-  set +ue
   exit_code=$?
+  set +ue
   dotnet-sonarscanner end /d:sonar.login="$SONAR_TOKEN"
   if [ "$exit_code" -eq 0 ]; then
     echo -e "\e[1;32m ________________________________________________________________\e[0m"


### PR DESCRIPTION
# Description

Support for more "intelligent" Test project recognizer.

The previous filter would run tests on ANY projects with "test" in the name.  In some repositories there are projects that are labeled "TestHelpers" or similar.  These are not test projects, so running dotnet tests on them would throw an exception and fail workflows.

The new filter, will ensure that any projects in the tests/ directory will get picked up and tested.
This goes along with Repo structure Doc : https://drivevariant.atlassian.net/wiki/spaces/TEC/pages/1373405447/Repository+Structure

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Sanity Testing

This is currently in use on a branch in message-publisher and message-handler repositories
Example Run: https://github.com/variant-inc/message-handler/runs/7024235487?check_suite_focus=true
## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
