### PR TITLE
Excludes package lock files from Sonar scanning

### DIFF
--- a/test/action.yml
+++ b/test/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Set up Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 
@@ -30,7 +30,7 @@ runs:
         key: ${{ github.repository }}-nuget
 
     - name: Set up Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 5.0.x
 
@@ -87,7 +87,7 @@ runs:
       with:
         files: Dockerfile
 
-    - uses: hadolint/hadolint-action@v3.1.0
+    - uses: hadolint/hadolint-action@v3.2.0
       if: steps.check_dockerfile.outputs.files_exists == 'true'
       with:
         dockerfile: Dockerfile

--- a/test/sonarscan.sh
+++ b/test/sonarscan.sh
@@ -24,15 +24,15 @@ trap "err" ERR
 # echo "Sonar Wait Flag: $wait_flag"
 
 sonar_args="/o:$SONAR_ORGANIZATION \
-    /k:$SONAR_PROJECT_KEY \
-    -d:sonar.host.url=https://sonarcloud.io \
-    -d:sonar.token=$SONAR_TOKEN \
-    -d:sonar.cs.opencover.reportsPaths=**/TestResults/*/coverage.opencover.xml \
-    -d:sonar.exclusions=**/*Migrations/**/* \
-    -d:sonar.scm.disabled=true \
-    -d:sonar.scm.revision=$GITHUB_SHA \
-    -d:sonar.qualitygate.wait=$wait_flag \
-	-d:sonar.scanner.scanAll=false"
+		/k:$SONAR_PROJECT_KEY \
+		-d:sonar.host.url=https://sonarcloud.io \
+		-d:sonar.token=$SONAR_TOKEN \
+		-d:sonar.cs.opencover.reportsPaths=**/TestResults/*/coverage.opencover.xml \
+		-d:sonar.exclusions=**/*Migrations/**/*,**/packages.lock.json \
+		-d:sonar.scm.disabled=true \
+		-d:sonar.scm.revision=$GITHUB_SHA \
+		-d:sonar.qualitygate.wait=$wait_flag \
+		-d:sonar.scanner.scanAll=false"
 
 if test -f "$GITHUB_WORKSPACE/coverage/hadolint.sonar"; then
 	cat "$GITHUB_WORKSPACE/coverage/hadolint.sonar"


### PR DESCRIPTION
# Description

Excludes package lock files from SonarQube scans to prevent unnecessary analysis and reduce noise in the results. This improves the efficiency and focus of the scanning process.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Sonar is at its limit. I was hoping that this would fix it but it didn't but it will help in the future.

https://github.com/usxpressinc/ops-trailers-ingestor/actions/runs/17466233858
https://github.com/usxpressinc/ops-trailers-ingestor/pull/5/checks?check_run_id=49604485953

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules